### PR TITLE
Fix scroll will reverse on Windows

### DIFF
--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -18,7 +18,11 @@ def scroll_fix(delta: int) -> int:
     if delta in (4, 5):
         # Linux device
         result = delta / 4 if delta == 4 else -delta / 5
-    result = -delta if SYSTEM == "Darwin" else delta / 120
+
+    if SYSTEM ==  "Windows":
+        result = -(delta / 120) # Must div 120 here, otherwise it will be too fast
+    else: 
+        result = -delta if SYSTEM == "Darwin" else delta / 120
     return int(result)
 
 

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -19,6 +19,7 @@ def scroll_fix(delta: int) -> int:
         return 1 if delta == 4 else -1
     elif SYSTEM == "Darwin":  # macOS
         return -delta
+
     # Windows, needs to be divided by 120
     return -(delta // 120)
 

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -15,11 +15,9 @@ def scroll_fix(delta: int) -> int:
     # The scroll events passed by macOS are different from Windows and Linux
     # so it must to be rectified to work properly when dealing with the events.
     # Originally found here: https://stackoverflow.com/a/17457843/17053202
-    if delta in (4, 5):
-        # X11 (maybe macOS with X11 too)
+    if delta in (4, 5):  # X11 (maybe macOS with X11 too)
         return 1 if delta == 4 else -1
-    elif SYSTEM == "Darwin":
-        # macOS
+    elif SYSTEM == "Darwin":  # macOS
         return -delta
     # Windows, needs to be divided by 120
     return -(delta // 120)

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -17,7 +17,8 @@ def scroll_fix(delta: int) -> int:
     # Originally found here: https://stackoverflow.com/a/17457843/17053202
     if delta in (4, 5):  # X11 (maybe macOS with X11 too)
         return 1 if delta == 4 else -1
-    elif SYSTEM == "Darwin":  # macOS
+    
+    if SYSTEM == "Darwin":  # macOS
         return -delta
 
     # Windows, needs to be divided by 120

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -12,18 +12,17 @@ SYSTEM = system()
 def scroll_fix(delta: int) -> int:
     """Corrects scrolling numbers across platforms"""
 
-    # The scroll events passed by MacOS are different from Windows and Linux
+    # The scroll events passed by macOS are different from Windows and Linux
     # so it must to be rectified to work properly when dealing with the events.
     # Originally found here: https://stackoverflow.com/a/17457843/17053202
     if delta in (4, 5):
-        # Linux device
-        result = delta / 4 if delta == 4 else -delta / 5
-
-    if SYSTEM ==  "Windows":
-        result = -(delta / 120) # Must div 120 here, otherwise it will be too fast
-    else: 
-        result = -delta if SYSTEM == "Darwin" else delta / 120
-    return int(result)
+        # X11 (maybe macOS with X11 too)
+        return 1 if delta == 4 else -1
+    elif SYSTEM == "Darwin":
+        # macOS
+        return -delta
+    # Windows, needs to be divided by 120
+    return -(delta // 120)
 
 
 class TkLineNumError(Exception):


### PR DESCRIPTION
fix #25

@Moosems, I have figure out why I can't fix it in #7 (I'm sorry)

On Windows. Not only  ```delta / 120``` to get the right speed but also ```-(delta / 120)``` to avoid the scroll reverse on Windows.