### PR TITLE
Adding tilde character parameter

### DIFF
--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -128,24 +128,24 @@ class TkLineNumbers(Canvas):
             if widget_font == "TkFixedFont":
                 # size 10 is hardcoded. It should be the current font size of TkFixedFont, but I could not
                 # find a way to get it, so 10 is working fine here. This is probably problematic.
-                _font = Font(family="TkFixedFont", size=10)
+                used_font = Font(family="TkFixedFont", size=10)
 
             # If user is using tkinter
             elif isinstance(widget_font, str):
                 # If user sent a tkinter Font instance
                 if "font" in widget_font:
-                    _font = Font(font=widget_font)
+                    used_font = Font(font=widget_font)
 
                 # If font family has 2+ words
                 elif "}" in widget_font:
-                    _family = widget_font.split("}")[0].replace("{", "")
-                    _size = widget_font.split("}")[1]
-                    _font = Font(family=_family, size=_size)
+                    used_family = widget_font.split("}")[0].replace("{", "")
+                    used_size = widget_font.split("}")[1]
+                    used_font = Font(family=used_family, size=used_size)
 
                 # If font family is just one word ("Consolas 20")
                 else:
                     cur_font = widget_font.split(" ")
-                    _font = Font(family=cur_font[0], size=cur_font[1])
+                    used_font = Font(family=cur_font[0], size=cur_font[1])
 
             # If user is using customtkinter
             # In customtkinter, fonts only accept tuple and CTkFont instance
@@ -155,10 +155,10 @@ class TkLineNumbers(Canvas):
                 )
 
             else:
-                _font = widget_font
+                used_font = widget_font
 
             # Get the max amount of lines that can fit in the textwidget
-            max_lines = self.textwidget.winfo_height() // _font.metrics()["linespace"]
+            max_lines = self.textwidget.winfo_height() // used_font.metrics()["linespace"]
 
             # Saving all wrapped lines occurrences
             wrapped_lines = 0
@@ -230,7 +230,7 @@ class TkLineNumbers(Canvas):
                     else int(self["width"])
                     if self.justify == "right"
                     else int(self["width"]) / 2,
-                    (lineno - 1) * _font.metrics()["linespace"],
+                    (lineno - 1) * used_font.metrics()["linespace"],
                     text=f" {self.tilde} "
                     if self.justify != "center"
                     else f"{self.tilde}",
@@ -424,7 +424,7 @@ class TkLineNumbers(Canvas):
 
 
 if __name__ == "__main__":
-    option = "ctk"
+    option = "tk"
 
     if option == "tk":
         from tkinter import Tk

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -163,16 +163,21 @@ class TkLineNumbers(Canvas):
             # Saving all wrapped lines occurrences
             wrapped_lines = 0
 
+            # Check if textwidget has the count method (CTkTextbox does not have it)
+            has_count_method = hasattr(self.textwidget, "count") and callable(getattr(self.textwidget, "count"))
+
+
         # Draw the line numbers looping through the lines
         for lineno in range(first_line, first_loop_range):
             # If user is using tilde chars, it is necessary to know how many wrapped lines
             if self.tilde:
-                try:
+                # If user is using tkinter Text class
+                if has_count_method:
                     is_wrapped = self.textwidget.count(
                         f"{lineno}.0", f"{lineno}.0 lineend", "displaylines"
                     )
                 # If user is using customtkinter and textwidget is a CTkTextbox instance
-                except AttributeError:
+                else:
                     is_wrapped = self.textwidget._textbox.count(
                         f"{lineno}.0", f"{lineno}.0 lineend", "displaylines"
                     )
@@ -420,7 +425,7 @@ class TkLineNumbers(Canvas):
 
 
 if __name__ == "__main__":
-    option = "tk"
+    option = "ctk"
 
     if option == "tk":
         from tkinter import Tk

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -128,7 +128,7 @@ class TkLineNumbers(Canvas):
             if widget_font == "TkFixedFont":
                 # size 10 is hardcoded. It should be the current font size of TkFixedFont, but I could not
                 # find a way to get it, so 10 is working fine here. This is probably problematic.
-                _font = Font(family="Arial", size=10)
+                _font = Font(family="TkFixedFont", size=10)
 
             # If user is using tkinter
             elif isinstance(widget_font, str):

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -159,24 +159,14 @@ class TkLineNumbers(Canvas):
             # Get the max amount of lines that can fit in the textwidget
             max_lines = self.textwidget.winfo_height() // _font.metrics()["linespace"]
 
-            # if the last line is greater than max_visible_lines, you won't need a tilde char
-            if int(last_line) < max_lines:
-            # If user send a tilde parameter, the loop range will change to the max visible lines in widget
-            # Else, loop range will be last_line + 1 (default)
-                _range = last_line + max_lines + 1 - int(self.textwidget.index("insert").split(".")[0]) if self.tilde is not None else last_line + 1
         
-        skip = []
-
+        wrapped_lines = 0
+        # Draw the line numbers looping through the lines
         for lineno in range(first_line, _range):
             is_wrapped = self.textwidget.count(f"{lineno}.0", f"{lineno}.0 lineend", "displaylines")
             if is_wrapped:
-                skip.append((lineno, lineno + is_wrapped[0]))
+                wrapped_lines += is_wrapped[0]
 
-        #print(skip)
-        
-
-        # Draw the line numbers looping through the lines
-        for lineno in range(first_line, _range):
 
             # Check if line is elided
             tags: tuple[str] = self.textwidget.tag_names(f"{lineno}.0")
@@ -208,15 +198,8 @@ class TkLineNumbers(Canvas):
                 )
             
             elif self.tilde:
-                skip_loop = False
-                for i in skip:
-                    if i[1] >= lineno > i[0]:
-                        skip_loop = True
-
-                if skip_loop: continue
                 # Only create tilde char if the current line is less than max_lines
                 if lineno <= max_lines:
-                    print("criando tilde em ",lineno)
                 # Creates the tilde character
                     self.create_text(
                         0
@@ -231,6 +214,26 @@ class TkLineNumbers(Canvas):
                         fill=self.foreground_color,
                     )
                 continue
+        
+        _range2 = last_line + max_lines + 1 - int(self.textwidget.index("insert").split(".")[0])
+        for lineno in range(_range + wrapped_lines, _range2):
+            print(_range, _range2)
+            # Only create tilde char if the current line is less than max_lines
+            if lineno <= max_lines:
+            # Creates the tilde character
+                self.create_text(
+                    0
+                    if self.justify == "left"
+                    else int(self["width"])
+                    if self.justify == "right"
+                    else int(self["width"]) / 2,
+                    (lineno - 1) * _font.metrics()["linespace"],
+                    text=f" {self.tilde} " if self.justify != "center" else f"{self.tilde}",
+                    anchor={"left": "nw", "right": "ne", "center": "n"}[self.justify],
+                    font=self.textwidget.cget("font"),
+                    fill=self.foreground_color,
+                )
+
 
     def mouse_scroll(self, event: Event) -> None:
         """Scrolls the text widget when the mouse wheel is scrolled -- Internal use only"""

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -162,7 +162,7 @@ class TkLineNumbers(Canvas):
             if int(last_line) < max_lines:
             # If user send a tilde parameter, the loop range will change to the max visible lines in widget
             # Else, loop range will be last_line + 1 (default)
-                _range = last_line + max_lines + 1 if self.tilde is not None else last_line + 1
+                _range = last_line + max_lines + 1 - int(self.textwidget.index("insert").split(".")[0]) if self.tilde is not None else last_line + 1
         
         # Draw the line numbers looping through the lines
         for lineno in range(first_line, _range):
@@ -455,8 +455,8 @@ if __name__ == "__main__":
         # customtkinter sends font type as CtkFont() instance or tuple
 
         # both are accepted in customtkinter
-        #_font = ctk.CTkFont("Consolas", 20)
-        _font = ("Consolas", 20)
+        _font = ctk.CTkFont("Consolas", 20)
+        #_font = ("Consolas", 20)
         
         # both are not accepted in customtkinter
         # _font = Font(family="Consolas", size=20)

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from platform import system
 from tkinter import Canvas, Event, Misc, Text, getboolean
+from tkinter.font import Font
 from typing import Callable, Optional
 
 from customtkinter import CTkFont

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -167,9 +167,16 @@ class TkLineNumbers(Canvas):
         for lineno in range(first_line, first_loop_range):
             # If user is using tilde chars, it is necessary to know how many wrapped lines
             if self.tilde:
-                is_wrapped = self.textwidget.count(
-                    f"{lineno}.0", f"{lineno}.0 lineend", "displaylines"
-                )
+                try:
+                    is_wrapped = self.textwidget.count(
+                        f"{lineno}.0", f"{lineno}.0 lineend", "displaylines"
+                    )
+                # If user is using customtkinter and textwidget is a CTkTextbox instance
+                except AttributeError:
+                    is_wrapped = self.textwidget._textbox.count(
+                        f"{lineno}.0", f"{lineno}.0 lineend", "displaylines"
+                    )
+
                 if is_wrapped:
                     wrapped_lines += is_wrapped[0]
 

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -48,7 +48,7 @@ class TkLineNumbers(Canvas):
         # None means take colors from text widget (default).
         # Otherwise it is a function that takes no arguments and returns (fg, bg) tuple.
         colors: Callable[[], tuple[str, str]] | tuple[str, str] | None = None,
-        tilde: str | None = None,
+        tilde: str | None = "~",
         *args,
         **kwargs,
     ) -> None:
@@ -409,7 +409,7 @@ class TkLineNumbers(Canvas):
 
 
 if __name__ == "__main__":
-    option = "ctk"
+    option = "tk"
 
     if option == "tk":
         from tkinter import Tk

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from platform import system
 from tkinter import Canvas, Event, Misc, Text, getboolean
-from tkinter.font import Font
+from tkinter.font import Font, nametofont
 from typing import Callable, Optional
 
 from customtkinter import CTkFont
@@ -134,24 +134,24 @@ class TkLineNumbers(Canvas):
         # If user is using tkinter
         elif type(widget_font) == str:
             
+            # If user sent a tkinter Font instance
+            if "font" in widget_font:
+                _font = Font(font=widget_font)
+
             # If font family has 2+ words
-            if "}" in widget_font:
+            elif "}" in widget_font:
                 _family = widget_font.split("}")[0].replace("{", "")
                 _size = widget_font.split("}")[1]
                 _font = Font(family=_family, size=_size)
             
-
+            # If font family is just one word ("Consolas 20")
             else:
                 cur_font = widget_font.split(" ")
                 _font = Font(family=cur_font[0], size=cur_font[1])
 
         # If user is using customtkinter        
         # In customtkinter, fonts only accept tuples and CTkFont instance
-        elif type(widget_font) == tuple:
-            _font = CTkFont(family=widget_font[0], size=widget_font[1])
-        
-        else:
-            _font = widget_font
+        else: _font = CTkFont(family=widget_font[0], size=widget_font[1]) if type(widget_font) == tuple else widget_font
         
             
         # Only calculate max_lines if user send a tilde char, for optimization reasons
@@ -209,6 +209,7 @@ class TkLineNumbers(Canvas):
                         font=self.textwidget.cget("font"),
                         fill=self.foreground_color,
                     )
+                    
                 continue
             # Create the line number
             self.create_text(
@@ -409,7 +410,7 @@ class TkLineNumbers(Canvas):
 
 
 if __name__ == "__main__":
-    option = "tk"
+    option = "ctk"
 
     if option == "tk":
         from tkinter import Tk
@@ -437,9 +438,10 @@ if __name__ == "__main__":
         text.bind("<KeyRelease>", lambda _: text.after_idle(linenums.redraw))
 
         # tkinter sends font as str
+        # all these examples below must work correctly:
         #text.config(font=Font(root, family="Consolas", size=20))
         #text.config(font="Consolas 20")
-        #text.config(font=("Courier New", 20))
+        text.config(font=("Courier New", 20))
 
         root.mainloop()
     
@@ -456,13 +458,14 @@ if __name__ == "__main__":
         # customtkinter sends font type as CtkFont() instance or tuple
 
         # both are accepted in customtkinter
-        _font = ctk.CTkFont("Consolas", 20)
-        # _font = ("Consolas", 20)
+        #_font = ctk.CTkFont("Consolas", 20)
+        _font = ("Consolas", 20)
         
         # both are not accepted in customtkinter
         # _font = Font(family="Consolas", size=20)
         # _font = "Consolas 20"
 
+        # comment _font and the line below to test the default ctk font
         textbox.configure(font=_font)
 
         linecounter = TkLineNumbers(root, textbox, justify="left", colors=("#e3ba68", "#1D1E1E"),tilde="~", bd=0)

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -149,7 +149,7 @@ class TkLineNumbers(Canvas):
 
             # If user is using customtkinter
             # In customtkinter, fonts only accept tuple and CTkFont instance
-            elif type(widget_font) == tuple:
+            elif isinstance(widget_font, tuple):
                 raise TypeError(
                     "Tuple fonts type does not work correctly with the tilde parameter. Use a CTkFont() instance instead."
                 )

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from platform import system
-from tkinter import Canvas, Event, Misc, Text  # , getboolean
+from tkinter import Canvas, Event, Misc, Text, getboolean
 from tkinter.font import Font
 from typing import Callable, Optional
 
@@ -182,17 +182,17 @@ class TkLineNumbers(Canvas):
                     is_wrapped = self.textwidget._textbox.count(
                         f"{lineno}.0", f"{lineno}.0 lineend", "displaylines"
                     )
-
+                # If the line is wrapped, add to wrapped_lines the number of visible lines that it is occupying
                 if is_wrapped:
                     wrapped_lines += is_wrapped[0]
 
             # Check if line is elided
-            # tags: tuple[str] = self.textwidget.tag_names(f"{lineno}.0")
-            # elide_values: tuple[str] = (
-            #     self.textwidget.tag_cget(tag, "elide") for tag in tags
-            # )
+            tags: tuple[str] = self.textwidget.tag_names(f"{lineno}.0")
+            elide_values: tuple[str] = (
+                self.textwidget.tag_cget(tag, "elide") for tag in tags
+            )
             # elide values can be empty
-            # line_elided: bool = any(getboolean(v or "false") for v in elide_values)
+            line_elided: bool = any(getboolean(v or "false") for v in elide_values)
 
             # If the line is not visible, skip it
             dlineinfo: tuple[

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -164,8 +164,9 @@ class TkLineNumbers(Canvas):
             wrapped_lines = 0
 
             # Check if textwidget has the count method (CTkTextbox does not have it)
-            has_count_method = hasattr(self.textwidget, "count") and callable(getattr(self.textwidget, "count"))
-
+            has_count_method = hasattr(self.textwidget, "count") and callable(
+                getattr(self.textwidget, "count")
+            )
 
         # Draw the line numbers looping through the lines
         for lineno in range(first_line, first_loop_range):

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -218,9 +218,7 @@ class TkLineNumbers(Canvas):
         # Only create tilde char if the max_lines (max visible lines) is greater than last_line + wrapped_line_amount
         if self.tilde and max_lines > last_line + wrapped_lines:
             # The second_loop_range will be the last visible line in textwidget
-            second_loop_range = (last_line + max_lines + 1) - int(
-                self.textwidget.index("insert").split(".")[0]
-            )
+            second_loop_range = (last_line + max_lines + 2) - first_loop_range
 
             # After drawing the numbers, iterate from the last content line to the last visible line, to add tilde chars
             # the wrapped_lines are added in first_loop_range to ignore all visible wrapped lines

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -127,12 +127,23 @@ class TkLineNumbers(Canvas):
 
         # If tkinter default font is in use
         if widget_font == "TkFixedFont":
-            _font = CTkFont(family="TkFixedFont", size=11)
+            # size 13 is hardcoded. It should be the current font size of TkFixedFont, but I could not
+            # find a way to get it, so 13 is working fine here. This is probably problematic.
+            _font = CTkFont(family="TkFixedFont", size=13)
 
         # If user is using tkinter
         elif type(widget_font) == str:
-            cur_font = widget_font.split(" ")
-            _font = Font(family=cur_font[0], size=cur_font[1])
+            
+            # If font family has 2+ words
+            if "}" in widget_font:
+                _family = widget_font.split("}")[0].replace("{", "")
+                _size = widget_font.split("}")[1]
+                _font = Font(family=_family, size=_size)
+            
+
+            else:
+                cur_font = widget_font.split(" ")
+                _font = Font(family=cur_font[0], size=cur_font[1])
 
         # If user is using customtkinter        
         # In customtkinter, fonts only accept tuples and CTkFont instance
@@ -427,8 +438,8 @@ if __name__ == "__main__":
 
         # tkinter sends font as str
         #text.config(font=Font(root, family="Consolas", size=20))
-        text.config(font="Consolas 20")
-        text.config(font="Courier 20")
+        #text.config(font="Consolas 20")
+        #text.config(font=("Courier New", 20))
 
         root.mainloop()
     

--- a/tklinenums/tklinenums.py
+++ b/tklinenums/tklinenums.py
@@ -6,8 +6,6 @@ from tkinter import Canvas, Event, Misc, Text, getboolean
 from tkinter.font import Font
 from typing import Callable, Optional
 
-from customtkinter import CTkFont
-
 
 SYSTEM = system()
 
@@ -131,7 +129,7 @@ class TkLineNumbers(Canvas):
             if widget_font == "TkFixedFont":
                 # size 13 is hardcoded. It should be the current font size of TkFixedFont, but I could not
                 # find a way to get it, so 13 is working fine here. This is probably problematic.
-                _font = CTkFont(family="TkFixedFont", size=13)
+                _font = Font(family="TkFixedFont", size=13)
 
             # If user is using tkinter
             elif type(widget_font) == str:
@@ -152,9 +150,12 @@ class TkLineNumbers(Canvas):
                     _font = Font(family=cur_font[0], size=cur_font[1])
 
             # If user is using customtkinter        
-            # In customtkinter, fonts only accept tuples and CTkFont instance
-            else: _font = CTkFont(family=widget_font[0], size=widget_font[1]) if type(widget_font) == tuple else widget_font
-        
+            # In customtkinter, fonts only accept tuple and CTkFont instance
+            elif type(widget_font) == tuple:
+                raise TypeError(f"Tuple fonts type does not work correctly with the tilde parameter. Use a CTkFont() instance instead.")
+                
+            else: _font = widget_font
+            
             # Get the max amount of lines that can fit in the textwidget
             max_lines = self.textwidget.winfo_height() // _font.metrics()["linespace"]
 
@@ -454,8 +455,9 @@ if __name__ == "__main__":
 
         # customtkinter sends font type as CtkFont() instance or tuple
 
-        # both are accepted in customtkinter
+        # both _font are accepted in customtkinter
         _font = ctk.CTkFont("Consolas", 20)
+        # using a tuple type font will break tilde system
         #_font = ("Consolas", 20)
         
         # both are not accepted in customtkinter


### PR DESCRIPTION
With my contribution, user can add a tilde character parameter to the TkLineNums widget. If user doesn't send this parameter, TkLineNums will work normally, without a tilde character.
example: `self.line_counter = TkLineNumbers(master, self, justify="right", colors=("#e3ba68", "#1D1E1E"),tilde="~", bd=0)`

Example of tilde character in Vim text editor:
![intro-vim-unix-text-editor-every-hacker-should-be-familiar-with w1456](https://github.com/Moosems/TkLineNums/assets/133379234/72d4f724-9c80-4bba-acb4-c4ef4ff8b180)
In this case, "~" is the tilde character, and it represents a non-existent line.

In my code, there is a visual bug that I could not find a fix. If user have a wrapped line (a big line that don't fit in the text widget resolution, so It "breaks" into 2+ visible lines), the tilde algorithm will try to add a tilde character in that counter position, causing a visual bug.

example:
![image](https://github.com/Moosems/TkLineNums/assets/133379234/afe0aa06-f5f3-45dd-aa32-72f92a24ab3c)

this tilde character overlapping with the "7" in the line counter was created because of the wrapped line space.

This bug only happen if:
![image](https://github.com/Moosems/TkLineNums/assets/133379234/a730c843-89af-4ec8-89ae-95d59071289e)

If we fix this visual problem, tilde characters will work flawlessly! =)